### PR TITLE
feat(utils): add variance calculation function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "release-test-core",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "release-test"
 path = "src/main.rs"
 
 [dependencies]
-release-test-core = { path = "../core", version = "0.1.0" }
-release-test-utils = { path = "../utils", version = "0.1.0" }
+release-test-core = { path = "../core", version = "0.2.0" }
+release-test-utils = { path = "../utils", version = "0.2.0" }
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -8,5 +8,5 @@ repository.workspace = true
 description = "Utility functions for release-test project"
 
 [dependencies]
-release-test-core = { path = "../core", version = "0.1.0" }
+release-test-core = { path = "../core", version = "0.2.0" }
 serde_json.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -29,7 +29,7 @@ pub fn calculate_median(values: &mut [f64]) -> Option<f64> {
     Some(median)
 }
 
-pub fn calculate_std_deviation(values: &[f64]) -> Option<f64> {
+pub fn calculate_variance(values: &[f64]) -> Option<f64> {
     if values.is_empty() {
         return None;
     }
@@ -39,7 +39,11 @@ pub fn calculate_std_deviation(values: &[f64]) -> Option<f64> {
         .map(|x| (x - mean).powi(2))
         .sum::<f64>() / values.len() as f64;
     
-    Some(variance.sqrt())
+    Some(variance)
+}
+
+pub fn calculate_std_deviation(values: &[f64]) -> Option<f64> {
+    calculate_variance(values).map(|v| v.sqrt())
 }
 
 #[cfg(test)]
@@ -78,6 +82,26 @@ mod tests {
         
         let mut empty: Vec<f64> = vec![];
         assert_eq!(calculate_median(&mut empty), None);
+    }
+
+    #[test]
+    fn test_calculate_variance() {
+        // Test with simple values
+        let values = vec![2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
+        let variance = calculate_variance(&values).unwrap();
+        assert!((variance - 4.0).abs() < 0.01);
+        
+        // Test with single value
+        let values = vec![5.0];
+        assert_eq!(calculate_variance(&values), Some(0.0));
+        
+        // Test with empty array
+        let empty: Vec<f64> = vec![];
+        assert_eq!(calculate_variance(&empty), None);
+        
+        // Test with identical values
+        let values = vec![3.0, 3.0, 3.0, 3.0];
+        assert_eq!(calculate_variance(&values), Some(0.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `calculate_variance` function to complement standard deviation
- Refactors `calculate_std_deviation` to use variance internally
- Returns `Option<f64>` for consistent API

## Changes
- New `calculate_variance` function in `crates/utils/src/lib.rs`
- Refactored standard deviation to use variance
- Added comprehensive test coverage
- Updated internal dependency versions to 0.2.0

## Test Plan
- [x] All unit tests pass
- [x] Variance calculation is correct
- [x] Standard deviation still works correctly
- [x] Edge cases handled (empty arrays, single values)

Closes #5