### PR TITLE
feat(utils): add min/max utility functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "release-test-core",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 release-test-core = { path = "../core", version = "0.2.0" }
-release-test-utils = { path = "../utils", version = "0.2.0" }
+release-test-utils = { path = "../utils", version = "0.3.0" }
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -46,6 +46,14 @@ pub fn calculate_std_deviation(values: &[f64]) -> Option<f64> {
     calculate_variance(values).map(|v| v.sqrt())
 }
 
+pub fn find_min(values: &[f64]) -> Option<f64> {
+    values.iter().copied().min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+}
+
+pub fn find_max(values: &[f64]) -> Option<f64> {
+    values.iter().copied().max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,5 +130,21 @@ mod tests {
         // Test with identical values
         let values = vec![3.0, 3.0, 3.0, 3.0];
         assert_eq!(calculate_std_deviation(&values), Some(0.0));
+    }
+
+    #[test]
+    fn test_find_min() {
+        assert_eq!(find_min(&[3.0, 1.0, 4.0, 2.0]), Some(1.0));
+        assert_eq!(find_min(&[42.0]), Some(42.0));
+        assert_eq!(find_min(&[]), None);
+        assert_eq!(find_min(&[-5.0, 0.0, 5.0]), Some(-5.0));
+    }
+
+    #[test]
+    fn test_find_max() {
+        assert_eq!(find_max(&[3.0, 1.0, 4.0, 2.0]), Some(4.0));
+        assert_eq!(find_max(&[42.0]), Some(42.0));
+        assert_eq!(find_max(&[]), None);
+        assert_eq!(find_max(&[-5.0, 0.0, 5.0]), Some(5.0));
     }
 }


### PR DESCRIPTION
## Summary
Adds basic min/max functions to complete our statistics utilities.

## Changes
- `find_min` function to find minimum value
- `find_max` function to find maximum value  
- Both return `Option<f64>` for consistency
- Comprehensive test coverage

Closes #7