### PR TITLE
fix(cli): correct CLI description and add empty name validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "release-test-core",
  "serde_json",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,7 @@ use release_test_utils::{format_data, serialize_data};
 
 #[derive(Parser)]
 #[command(name = "release-test")]
-#[command(about = "A test CLI for release-plz", long_about = None)]
+#[command(about = "A demo CLI for automated release testing", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -21,7 +21,7 @@ enum Commands {
         #[arg(short, long)]
         value: f64,
     },
-    
+
     Format {
         #[arg(short, long)]
         json: bool,
@@ -33,6 +33,9 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Process { id, name, value } => {
+            if name.is_empty() {
+                anyhow::bail!("Name cannot be empty");
+            }
             let model = DataModel::new(id, name, value)?;
             println!("Original: {}", format_data(&model));
             println!("Processed value: {}", model.process());

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 pub enum CoreError {
     #[error("processing error: {0}")]
     ProcessingError(String),
-    
+
     #[error("validation error: {0}")]
     ValidationError(String),
 }
@@ -20,19 +20,21 @@ pub struct DataModel {
 impl DataModel {
     pub fn new(id: u64, name: String, value: f64) -> Result<Self, CoreError> {
         if name.is_empty() {
-            return Err(CoreError::ValidationError("Name cannot be empty".to_string()));
+            return Err(CoreError::ValidationError(
+                "Name cannot be empty".to_string(),
+            ));
         }
         Ok(Self { id, name, value })
     }
-    
+
     pub fn process(&self) -> f64 {
         self.value * 2.0
     }
-    
+
     pub fn squared(&self) -> f64 {
         self.value * self.value
     }
-    
+
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -9,11 +9,8 @@ pub fn serialize_data(model: &DataModel) -> Result<String, serde_json::Error> {
 }
 
 pub fn calculate_average(values: &[f64]) -> f64 {
-    let valid_values: Vec<f64> = values.iter()
-        .copied()
-        .filter(|x| x.is_finite())
-        .collect();
-    
+    let valid_values: Vec<f64> = values.iter().copied().filter(|x| x.is_finite()).collect();
+
     if valid_values.is_empty() {
         return 0.0;
     }
@@ -35,20 +32,16 @@ pub fn calculate_median(values: &mut [f64]) -> Option<f64> {
 }
 
 pub fn calculate_variance(values: &[f64]) -> Option<f64> {
-    let valid_values: Vec<f64> = values.iter()
-        .copied()
-        .filter(|x| x.is_finite())
-        .collect();
-    
+    let valid_values: Vec<f64> = values.iter().copied().filter(|x| x.is_finite()).collect();
+
     if valid_values.is_empty() {
         return None;
     }
-    
+
     let mean = calculate_average(&valid_values);
-    let variance = valid_values.iter()
-        .map(|x| (x - mean).powi(2))
-        .sum::<f64>() / valid_values.len() as f64;
-    
+    let variance =
+        valid_values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / valid_values.len() as f64;
+
     Some(variance)
 }
 
@@ -57,11 +50,17 @@ pub fn calculate_std_deviation(values: &[f64]) -> Option<f64> {
 }
 
 pub fn find_min(values: &[f64]) -> Option<f64> {
-    values.iter().copied().min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    values
+        .iter()
+        .copied()
+        .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
 }
 
 pub fn find_max(values: &[f64]) -> Option<f64> {
-    values.iter().copied().max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    values
+        .iter()
+        .copied()
+        .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
 }
 
 #[cfg(test)]
@@ -88,7 +87,7 @@ mod tests {
     fn test_calculate_average() {
         assert_eq!(calculate_average(&[1.0, 2.0, 3.0]), 2.0);
         assert_eq!(calculate_average(&[]), 0.0);
-        
+
         // Test NaN handling
         assert_eq!(calculate_average(&[1.0, 2.0, f64::NAN, 3.0]), 2.0);
         assert_eq!(calculate_average(&[f64::NAN, f64::NAN]), 0.0);
@@ -99,10 +98,10 @@ mod tests {
     fn test_calculate_median() {
         let mut values = vec![1.0, 2.0, 3.0];
         assert_eq!(calculate_median(&mut values), Some(2.0));
-        
+
         let mut values = vec![1.0, 2.0, 3.0, 4.0];
         assert_eq!(calculate_median(&mut values), Some(2.5));
-        
+
         let mut empty: Vec<f64> = vec![];
         assert_eq!(calculate_median(&mut empty), None);
     }
@@ -113,19 +112,19 @@ mod tests {
         let values = vec![2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let variance = calculate_variance(&values).unwrap();
         assert!((variance - 4.0).abs() < 0.01);
-        
+
         // Test with single value
         let values = vec![5.0];
         assert_eq!(calculate_variance(&values), Some(0.0));
-        
+
         // Test with empty array
         let empty: Vec<f64> = vec![];
         assert_eq!(calculate_variance(&empty), None);
-        
+
         // Test with identical values
         let values = vec![3.0, 3.0, 3.0, 3.0];
         assert_eq!(calculate_variance(&values), Some(0.0));
-        
+
         // Test NaN handling
         let values = vec![2.0, 4.0, f64::NAN, 6.0];
         let variance = calculate_variance(&values).unwrap();
@@ -138,15 +137,15 @@ mod tests {
         let values = vec![2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let std_dev = calculate_std_deviation(&values).unwrap();
         assert!((std_dev - 2.0).abs() < 0.01);
-        
+
         // Test with single value
         let values = vec![5.0];
         assert_eq!(calculate_std_deviation(&values), Some(0.0));
-        
+
         // Test with empty array
         let empty: Vec<f64> = vec![];
         assert_eq!(calculate_std_deviation(&empty), None);
-        
+
         // Test with identical values
         let values = vec![3.0, 3.0, 3.0, 3.0];
         assert_eq!(calculate_std_deviation(&values), Some(0.0));


### PR DESCRIPTION
## Summary
- Fixed incorrect CLI description that referenced "release-plz" instead of describing the actual purpose
- Added validation to prevent empty names in the Process command
- Improved error handling with explicit error message for empty names

## Changes
- Updated CLI about text from "A test CLI for release-plz" to "A demo CLI for automated release testing"
- Added empty name validation in the Process command with appropriate error message
- Code has been formatted with `cargo fmt` and passes `cargo clippy`

## Test Plan
- [x] All existing tests pass (`cargo test`)
- [x] Manually tested that empty names are rejected with clear error message
- [x] Code quality checks pass (fmt and clippy)

This is a bug fix that will trigger a patch release (0.3.1 → 0.3.2) when merged to main.