### PR TITLE
fix(ci): handle multi-package releases in artifact upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,11 +33,11 @@ jobs:
         run: cargo build --release
         
       - name: Upload Release Artifacts
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Upload binary to the release
-          gh release upload ${{ steps.release.outputs.tag_name }} \
+          # Upload binary to the CLI release (only when CLI is released)
+          gh release upload ${{ steps.release.outputs['release-test-cli--tag_name'] }} \
             target/release/release-test \
             --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-utils"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "release-test-core",
  "serde_json",


### PR DESCRIPTION
## Summary
Fixed the release workflow failure that occurs when multiple packages are released simultaneously.

## Problem
The workflow was failing with "requires at least 2 arg(s), only received 1" because:
- When multiple packages release, `steps.release.outputs.tag_name` is empty
- Each package has its own tag output like `release-test-cli--tag_name`

## Solution
- Changed to use package-specific outputs
- Only upload artifacts when the CLI package is released (since that's where the binary comes from)
- Use the CLI-specific tag name for the upload

## Test Plan
- [x] Workflow syntax is valid
- [x] Tests pass
- [x] Code quality checks pass

This will prevent the workflow failures we saw with the v0.3.2 release where multiple packages were released together.