### PR TITLE
fix(cli): improve help text and add version flag

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,7 @@ use release_test_utils::{format_data, serialize_data};
 
 #[derive(Parser)]
 #[command(name = "release-test")]
-#[command(about = "A demo CLI for automated release testing", long_about = None)]
+#[command(version, about = "A demo CLI for automated release testing", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -13,16 +13,22 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Process data with the given parameters
     Process {
+        /// Unique identifier for the data
         #[arg(short, long)]
         id: u64,
+        /// Name or label for the data
         #[arg(short, long)]
         name: String,
+        /// Numeric value to process
         #[arg(short, long)]
         value: f64,
     },
 
+    /// Format and display sample data
     Format {
+        /// Output in JSON format instead of plain text
         #[arg(short, long)]
         json: bool,
     },


### PR DESCRIPTION
## Summary
Improved the CLI user experience by adding comprehensive help documentation and version support.

## Changes
- ✨ Added descriptive help text for all commands and arguments
- 🏷️ Added version flag support (`--version`/`-V`)
- 📝 Enhanced argument descriptions for better clarity

## Examples

### Before
```
Commands:
  process
  format
```

### After
```
Commands:
  process  Process data with the given parameters
  format   Format and display sample data
```

### Detailed Help
```bash
$ release-test process --help
Process data with the given parameters

Usage: release-test process --id <ID> --name <NAME> --value <VALUE>

Options:
  -i, --id <ID>        Unique identifier for the data
  -n, --name <NAME>    Name or label for the data
  -v, --value <VALUE>  Numeric value to process
  -h, --help           Print help
```

## Impact
This fix improves usability by making the CLI self-documenting. Users can now understand what each command does without referring to external documentation.

## Test Plan
- [x] Tested `--help` flag shows improved descriptions
- [x] Tested `process --help` shows argument descriptions
- [x] Tested `--version` flag works
- [x] All tests pass
- [x] Code formatted and clippy clean

This will trigger a patch release for the CLI crate (0.3.2 → 0.3.3).