### PR TITLE
feat: add comprehensive binary building and release automation

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,0 +1,155 @@
+name: Build Release Binaries
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: release-test
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: release-test
+            archive: tar.gz
+            cross: true
+          
+          # macOS
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary: release-test
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary: release-test
+            archive: tar.gz
+          
+          # Windows
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: release-test.exe
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build binary
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} --bin release-test
+          else
+            cargo build --release --target ${{ matrix.target }} --bin release-test
+          fi
+        shell: bash
+
+      - name: Package binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf release-test-${{ matrix.target }}.tar.gz ${{ matrix.binary }}
+          mv release-test-${{ matrix.target }}.tar.gz ../../../
+        shell: bash
+
+      - name: Package binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a -tzip release-test-${{ matrix.target }}.zip ${{ matrix.binary }}
+          mv release-test-${{ matrix.target }}.zip ../../../
+        shell: bash
+
+      - name: Upload to Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            gh release upload ${{ github.event.release.tag_name }} \
+              release-test-${{ matrix.target }}.zip \
+              --clobber
+          else
+            gh release upload ${{ github.event.release.tag_name }} \
+              release-test-${{ matrix.target }}.tar.gz \
+              --clobber
+          fi
+        shell: bash
+
+  build-universal-macos:
+    name: Build Universal macOS Binary
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin,aarch64-apple-darwin
+
+      - name: Build both architectures
+        run: |
+          cargo build --release --target x86_64-apple-darwin --bin release-test
+          cargo build --release --target aarch64-apple-darwin --bin release-test
+
+      - name: Create universal binary
+        run: |
+          lipo -create \
+            target/x86_64-apple-darwin/release/release-test \
+            target/aarch64-apple-darwin/release/release-test \
+            -output release-test-universal
+          chmod +x release-test-universal
+          tar czf release-test-universal-apple-darwin.tar.gz release-test-universal
+
+      - name: Upload to Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            release-test-universal-apple-darwin.tar.gz \
+            --clobber
+
+  generate-checksums:
+    name: Generate checksums
+    needs: [build-binaries, build-universal-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download all release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.event.release.tag_name }} --dir ./artifacts
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum * > checksums.txt
+          cat checksums.txt
+
+      - name: Upload checksums
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            artifacts/checksums.txt \
+            --clobber

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,57 @@
+name: Manual Release Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build binaries for'
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: release-test
+          
+          # macOS
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary: release-test
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary: release-test
+          
+          # Windows
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: release-test.exe
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }} --bin release-test
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-test-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ matrix.binary }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,24 +20,5 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           
-      # The following steps only run if a release was created
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created }}
-        
-      - name: Setup Rust
-        if: ${{ steps.release.outputs.releases_created }}
-        uses: dtolnay/rust-toolchain@stable
-        
-      - name: Build release binaries
-        if: ${{ steps.release.outputs.releases_created }}
-        run: cargo build --release
-        
-      - name: Upload Release Artifacts
-        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Upload binary to the CLI release (only when CLI is released)
-          gh release upload ${{ steps.release.outputs['release-test-cli--tag_name'] }} \
-            target/release/release-test \
-            --clobber
+      # Note: Binary building and upload is handled by build-release-binaries.yml
+      # which is triggered automatically when a release is created

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "release-test-core",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A complete working example of automated releases for Rust multi-workspace projects using release-please.
 
+## Installation
+
+### Quick Install (Unix/macOS/WSL)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joshrotenberg/release-test-project/main/install.sh | bash
+```
+
+Or with wget:
+```bash
+wget -qO- https://raw.githubusercontent.com/joshrotenberg/release-test-project/main/install.sh | bash
+```
+
+### Download Binaries
+
+Pre-built binaries are available for:
+- Linux (x86_64, aarch64)
+- macOS (x86_64, aarch64, universal)
+- Windows (x86_64)
+
+Download from the [releases page](https://github.com/joshrotenberg/release-test-project/releases).
+
 > **✅ Working Solution**: `release-please` works perfectly with unpublished packages  
 > **❌ Failed Attempt**: `release-plz` requires crates.io publication  
 > **📖 Complete Guide**: [RELEASE_PLEASE_SETUP.md](RELEASE_PLEASE_SETUP.md) has step-by-step instructions

--- a/REDL_RELEASE_PLEASE_FIX.md
+++ b/REDL_RELEASE_PLEASE_FIX.md
@@ -1,0 +1,151 @@
+# Fixing release-please Setup for redl
+
+This document provides specific fixes for the redl repository's release-please configuration.
+
+## Current Issues Found
+
+1. **Missing version in internal dependency** (CRITICAL)
+   - Location: `crates/cli/Cargo.toml` line 40
+   - Current: `redis-commands = { path = "../redis-commands" }`
+   - Should be: `redis-commands = { path = "../redis-commands", version = "0.5.0" }`
+
+2. **Component naming inconsistency**
+   - The CLI package is named "redl" but component is "cli"
+   - This works but could be clearer
+
+3. **Workspace version field**
+   - Root Cargo.toml has `version = "0.1.0"` in workspace.package
+   - This is outdated compared to actual crate versions (0.5.0)
+
+## Immediate Fixes Needed
+
+### Fix 1: Update Internal Dependency (MOST IMPORTANT)
+
+Edit `crates/cli/Cargo.toml`:
+```toml
+# Line 40 - CHANGE FROM:
+redis-commands = { path = "../redis-commands" }
+
+# TO:
+redis-commands = { path = "../redis-commands", version = "0.5.0" }
+```
+
+### Fix 2: Update Root Workspace Version
+
+Edit root `Cargo.toml`:
+```toml
+[workspace.package]
+version = "0.5.0"  # Update from 0.1.0 to match current versions
+```
+
+### Fix 3: Update release-please Configuration (Optional but Recommended)
+
+Edit `release-please-config.json` to be consistent:
+```json
+{
+  "packages": {
+    "crates/cli": {
+      "release-type": "rust",
+      "package-name": "redl",
+      "component": "redl"  // Changed from "cli" to match package name
+    },
+    "crates/redis-commands": {
+      "release-type": "rust",
+      "package-name": "redis-commands",
+      "component": "redis-commands"
+    }
+  },
+  // ... rest stays the same
+}
+```
+
+## Commands to Apply Fixes
+
+```bash
+# 1. Create a branch for the fixes
+git checkout -b fix/release-please-internal-deps
+
+# 2. Apply the fixes to Cargo.toml files
+# (Make the edits described above)
+
+# 3. Test that everything still builds
+cargo build
+cargo test
+
+# 4. Commit with conventional message
+git add -A
+git commit -m "fix: add version to internal redis-commands dependency for release-please
+
+The redis-commands dependency in cli/Cargo.toml was missing a version field,
+which can cause release-please to incorrectly handle version bumps and
+dependency cascading.
+
+Also updated workspace version to match current crate versions."
+
+# 5. Push and create PR
+git push -u origin fix/release-please-internal-deps
+gh pr create --title "fix: add version to internal dependency for release-please" \
+  --body "Fixes internal dependency declaration to include version for proper release-please operation"
+```
+
+## Why These Fixes Matter
+
+1. **Missing version in path dependencies**: release-please needs both `path` and `version` to:
+   - Properly update versions during releases
+   - Handle dependency cascading (when redis-commands bumps, cli should too)
+   - Generate correct Cargo.lock entries
+
+2. **Component naming**: While not critical, having component match package name makes the tags clearer:
+   - Current: `cli-v0.5.0`
+   - Better: `redl-v0.5.0`
+
+## Verification After Fixes
+
+After merging the fix:
+1. Make a small change to redis-commands
+2. Commit with `fix:` or `feat:` prefix
+3. Push to main
+4. Verify release-please creates a PR that bumps BOTH crates (cascading)
+
+## Good News
+
+Your recent commits show release-please IS working! The main risk is that dependency cascading might not work correctly due to the missing version in the internal dependency.
+
+## If You Want to Start Fresh (Nuclear Option)
+
+Only if the above fixes don't work, here's how to completely reset:
+
+```bash
+# 1. Save your code
+cp -r . ../redl-backup
+
+# 2. Remove git history
+rm -rf .git
+
+# 3. Initialize fresh
+git init
+git branch -M main
+
+# 4. First commit - infrastructure
+git add release-please-config.json .release-please-manifest.json
+git add .github/workflows/
+git commit -m "build: add release-please configuration for automated releases"
+
+# 5. Second commit - the code
+git add .
+git commit -m "feat: initial implementation of Redis REPL with command registry"
+
+# 6. Force push to GitHub (THIS WILL DESTROY HISTORY)
+git remote add origin https://github.com/redis-field-engineering/redl.git
+git push -u origin main --force
+
+# 7. Update GitHub settings
+# Go to Settings → Actions → General
+# ✅ "Allow GitHub Actions to create and approve pull requests"
+```
+
+## Summary
+
+The redl project is VERY close to having perfect release-please setup. The main issue is the missing version in the internal dependency. Fix that first and test. The other issues are minor improvements.
+
+Your commit history already shows good conventional commit usage, so you probably don't need to start fresh unless the dependency fix doesn't resolve your issues.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+# Release Test Project Installation Script
+# This script downloads and installs the latest release of release-test
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+REPO="joshrotenberg/release-test-project"
+BINARY_NAME="release-test"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+# Functions
+print_error() {
+    echo -e "${RED}Error: $1${NC}" >&2
+}
+
+print_success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}$1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+detect_platform() {
+    local os arch
+
+    # Detect OS
+    case "$(uname -s)" in
+        Linux*)     os="linux";;
+        Darwin*)    os="darwin";;
+        CYGWIN*|MINGW*|MSYS*) os="windows";;
+        *)          print_error "Unsupported OS: $(uname -s)"; exit 1;;
+    esac
+
+    # Detect architecture
+    case "$(uname -m)" in
+        x86_64|amd64)   arch="x86_64";;
+        aarch64|arm64)  arch="aarch64";;
+        *)              print_error "Unsupported architecture: $(uname -m)"; exit 1;;
+    esac
+
+    # Construct target triple
+    case "${os}-${arch}" in
+        linux-x86_64)   echo "x86_64-unknown-linux-gnu";;
+        linux-aarch64)  echo "aarch64-unknown-linux-gnu";;
+        darwin-x86_64)  echo "x86_64-apple-darwin";;
+        darwin-aarch64) echo "aarch64-apple-darwin";;
+        windows-x86_64) echo "x86_64-pc-windows-msvc";;
+        *)              print_error "Unsupported platform: ${os}-${arch}"; exit 1;;
+    esac
+}
+
+download_binary() {
+    local target="$1"
+    local version="$2"
+    local download_url
+    local archive_name
+    local archive_ext
+
+    # Determine archive extension
+    if [[ "$target" == *"windows"* ]]; then
+        archive_ext="zip"
+    else
+        archive_ext="tar.gz"
+    fi
+
+    archive_name="${BINARY_NAME}-${target}.${archive_ext}"
+    
+    # Construct download URL
+    if [ "$version" = "latest" ]; then
+        download_url="https://github.com/${REPO}/releases/latest/download/${archive_name}"
+        print_info "Downloading latest version..."
+    else
+        download_url="https://github.com/${REPO}/releases/download/${version}/${archive_name}"
+        print_info "Downloading version ${version}..."
+    fi
+
+    # Download the archive
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$download_url" -o "$archive_name"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$download_url" -O "$archive_name"
+    else
+        print_error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+
+    print_success "Download complete!"
+    echo "$archive_name"
+}
+
+extract_binary() {
+    local archive="$1"
+    local target="$2"
+
+    print_info "Extracting binary..."
+
+    if [[ "$archive" == *.tar.gz ]]; then
+        tar -xzf "$archive"
+    elif [[ "$archive" == *.zip ]]; then
+        unzip -q "$archive"
+    else
+        print_error "Unknown archive format: $archive"
+        exit 1
+    fi
+
+    # Handle Windows .exe extension
+    local binary_file="$BINARY_NAME"
+    if [[ "$target" == *"windows"* ]]; then
+        binary_file="${BINARY_NAME}.exe"
+    fi
+
+    if [ ! -f "$binary_file" ]; then
+        print_error "Binary not found after extraction"
+        exit 1
+    fi
+
+    print_success "Extraction complete!"
+    echo "$binary_file"
+}
+
+install_binary() {
+    local binary_file="$1"
+
+    # Create install directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+
+    # Move binary to install directory
+    print_info "Installing to ${INSTALL_DIR}..."
+    mv "$binary_file" "${INSTALL_DIR}/${BINARY_NAME}"
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+    print_success "Installation complete!"
+
+    # Check if install directory is in PATH
+    if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+        print_warning "Warning: ${INSTALL_DIR} is not in your PATH"
+        print_info "Add the following to your shell configuration file:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    else
+        print_success "You can now run: ${BINARY_NAME} --help"
+    fi
+}
+
+cleanup() {
+    print_info "Cleaning up..."
+    rm -f "${BINARY_NAME}-"*.tar.gz "${BINARY_NAME}-"*.zip "${BINARY_NAME}" "${BINARY_NAME}.exe" 2>/dev/null || true
+}
+
+main() {
+    print_info "Release Test Project Installer"
+    print_info "==============================="
+    
+    # Parse arguments
+    local version="${1:-latest}"
+    
+    # Detect platform
+    local target
+    target=$(detect_platform)
+    print_info "Detected platform: $target"
+
+    # Create temp directory
+    local temp_dir
+    temp_dir=$(mktemp -d)
+    cd "$temp_dir"
+
+    # Set trap to cleanup on exit
+    trap cleanup EXIT
+
+    # Download binary
+    local archive
+    archive=$(download_binary "$target" "$version")
+
+    # Extract binary
+    local binary_file
+    binary_file=$(extract_binary "$archive" "$target")
+
+    # Install binary
+    install_binary "$binary_file"
+
+    # Cleanup is handled by trap
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
Added complete binary release automation with cross-platform support and easy installation methods.

## Features

### 🏗️ Automated Binary Building
- Triggers automatically when releases are created
- Cross-platform support: Linux, macOS, Windows
- Multiple architectures: x86_64, aarch64
- Universal macOS binary combining both architectures
- Automatic checksum generation for all artifacts

### 📦 Installation Methods
- **One-liner install script**: `curl -fsSL .../install.sh | bash`
- **Direct downloads**: From GitHub releases page
- **Platform detection**: Automatically selects right binary

### 🎯 Binary Targets
- **Linux**: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu
- **macOS**: x86_64-apple-darwin, aarch64-apple-darwin, universal
- **Windows**: x86_64-pc-windows-msvc

### 📝 Documentation
- Added installation instructions to README
- Created REDL_RELEASE_PLEASE_FIX.md with specific fixes for the redl project
- Identified missing version in internal dependency issue

## Workflows Added

1. **build-release-binaries.yml**: Automatic binary building on release creation
2. **manual-release.yml**: Manual workflow for testing builds

## How It Works

1. When release-please creates a release → triggers binary build workflow
2. Builds for all platforms in parallel
3. Uploads binaries to the release
4. Generates checksums for verification

## Testing
- [x] Workflow syntax is valid
- [x] Tests pass
- [x] Install script is executable

This feature will trigger a minor version bump when merged.