### PR TITLE
fix(cli): add proper exit code handling for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -37,7 +37,7 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Process { id, name, value } => {
             if name.is_empty() {
                 anyhow::bail!("Name cannot be empty");
@@ -45,6 +45,7 @@ fn main() -> Result<()> {
             let model = DataModel::new(id, name, value)?;
             println!("Original: {}", format_data(&model));
             println!("Processed value: {}", model.process());
+            Ok(())
         }
         Commands::Format { json } => {
             let model = DataModel::new(1, "example".to_string(), 100.0)?;
@@ -53,8 +54,15 @@ fn main() -> Result<()> {
             } else {
                 println!("{}", format_data(&model));
             }
+            Ok(())
         }
+    };
+
+    // Ensure proper exit code on error
+    if let Err(e) = &result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
     }
 
-    Ok(())
+    result
 }


### PR DESCRIPTION
## Summary
Added proper exit code handling to the CLI to make it more suitable for scripting and CI/CD environments.

## Problem
Previously, when the CLI encountered an error, it would print the error message but still exit with code 0 (success). This could cause issues in automated environments where scripts rely on exit codes to determine success/failure.

## Solution
- Capture the result of command execution
- On error: print to stderr and exit with code 1
- On success: exit with code 0

## Testing
```bash
# Test error case (should exit with code 1)
./release-test process --id 1 --name "" --value 42
echo $?  # Should print 1

# Test success case (should exit with code 0)
./release-test process --id 1 --name "test" --value 42
echo $?  # Should print 0
```

## Impact
This is a bug fix that improves CLI behavior for automation scenarios. Will trigger a patch release (0.3.3 → 0.3.4).

**This release will also be the first to test our new binary building automation!** 🎉