### PR TITLE
fix(ci): build binaries directly in release-please workflow

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -2,7 +2,7 @@ name: Build Release Binaries
 
 on:
   release:
-    types: [created]
+    types: [published, created]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,5 +20,29 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           
-      # Note: Binary building and upload is handled by build-release-binaries.yml
-      # which is triggered automatically when a release is created
+      # Build and upload binaries if CLI was released
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        
+      - name: Setup Rust
+        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+        
+      - name: Build Linux binary
+        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu --bin release-test
+          cd target/x86_64-unknown-linux-gnu/release
+          tar czf release-test-x86_64-unknown-linux-gnu.tar.gz release-test
+          mv release-test-x86_64-unknown-linux-gnu.tar.gz ../../../
+        
+      - name: Upload Linux binary
+        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.release.outputs['release-test-cli--tag_name'] }} \
+            release-test-x86_64-unknown-linux-gnu.tar.gz \
+            --clobber


### PR DESCRIPTION
## Summary
Fixed the binary building automation by integrating it directly into the release-please workflow.

## Problem
The separate `build-release-binaries.yml` workflow wasn't triggering on release events because:
- GitHub Actions tokens don't trigger other workflows by default (security feature)
- This prevents infinite loops but also blocks legitimate workflow chains

## Solution
Build and upload binaries directly in the release-please workflow when a CLI release is created.

## Current Implementation
- Builds Linux x86_64 binary as proof of concept
- Creates tar.gz archive
- Uploads to the release

## Next Steps
Once this works, we can:
- Add more platforms (macOS, Windows)
- Add more architectures (aarch64)
- Use matrix strategy for parallel builds

## Testing
This will be tested with the next release. The workflow will:
1. Detect CLI release via `steps.release.outputs['release-test-cli--release_created']`
2. Build the binary
3. Upload to the release

This fix ensures binaries are always built for new CLI releases!