### PR TITLE
fix(cli): add input validation for better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -42,6 +42,12 @@ fn main() -> Result<()> {
             if name.is_empty() {
                 anyhow::bail!("Name cannot be empty");
             }
+            if name.len() > 100 {
+                anyhow::bail!("Name too long (maximum 100 characters)");
+            }
+            if !value.is_finite() {
+                anyhow::bail!("Value must be a finite number (not NaN or infinity)");
+            }
             let model = DataModel::new(id, name, value)?;
             println!("Original: {}", format_data(&model));
             println!("Processed value: {}", model.process());


### PR DESCRIPTION
## Summary
Added comprehensive input validation to provide better error messages and prevent invalid data processing.

## Improvements
- ✅ Validate name length (maximum 100 characters)
- ✅ Check that value is finite (not NaN or infinity)
- ✅ Keep existing empty name validation

## Benefits
- Better user experience with clear error messages
- Catch errors early before processing
- Prevent edge cases with invalid numeric values

## Examples

```bash
# Name too long
./release-test process --id 1 --name "$(printf 'x%.0s' {1..101})" --value 42
# Error: Name too long (maximum 100 characters)

# Invalid value
./release-test process --id 1 --name "test" --value inf
# Error: Value must be a finite number (not NaN or infinity)

# Empty name (existing validation)
./release-test process --id 1 --name "" --value 42
# Error: Name cannot be empty
```

## Impact
This is a bug fix that improves input validation. Will trigger a patch release (0.3.4 → 0.3.5).

**This release will test our new binary building automation!** 🚀 The workflow now builds binaries directly in the release-please workflow.