### PR TITLE
fix(ci): debug and fix binary upload workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,18 +20,31 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           
-      # Build and upload binaries if CLI was released
+      # Debug outputs
+      - name: Debug release outputs
+        if: always()
+        run: |
+          echo "releases_created: ${{ steps.release.outputs.releases_created }}"
+          echo "release_created: ${{ steps.release.outputs.release_created }}"
+          echo "tag_name: ${{ steps.release.outputs.tag_name }}"
+          echo "cli specific:"
+          echo "  crates/cli--release_created: ${{ steps.release.outputs['crates/cli--release_created'] }}"
+          echo "  release-test-cli--release_created: ${{ steps.release.outputs['release-test-cli--release_created'] }}"
+          echo "All outputs:"
+          echo '${{ toJSON(steps.release.outputs) }}'
+      
+      # Build and upload binaries if any release was created
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        if: ${{ steps.release.outputs.releases_created }}
         
       - name: Setup Rust
-        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        if: ${{ steps.release.outputs.releases_created }}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
         
       - name: Build Linux binary
-        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        if: ${{ steps.release.outputs.releases_created }}
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu --bin release-test
           cd target/x86_64-unknown-linux-gnu/release
@@ -39,10 +52,13 @@ jobs:
           mv release-test-x86_64-unknown-linux-gnu.tar.gz ../../../
         
       - name: Upload Linux binary
-        if: ${{ steps.release.outputs['release-test-cli--release_created'] }}
+        if: ${{ steps.release.outputs.releases_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ steps.release.outputs['release-test-cli--tag_name'] }} \
+          # Get the latest release tag
+          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          echo "Uploading to release: $LATEST_TAG"
+          gh release upload "$LATEST_TAG" \
             release-test-x86_64-unknown-linux-gnu.tar.gz \
             --clobber

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -51,6 +51,7 @@ fn main() -> Result<()> {
             let model = DataModel::new(id, name, value)?;
             println!("Original: {}", format_data(&model));
             println!("Processed value: {}", model.process());
+            println!("Squared value: {}", model.squared());
             Ok(())
         }
         Commands::Format { json } => {


### PR DESCRIPTION
## Summary
Fixed the binary upload workflow to actually trigger and build binaries when releases are created.

## Changes
1. **Added debug output** to understand what outputs release-please provides
2. **Simplified trigger condition** to use `releases_created` instead of package-specific flags
3. **Dynamic tag retrieval** for uploading to the correct release
4. **Bonus**: Added squared value display to CLI output

## Debugging Approach
The workflow will now:
1. Print all release-please outputs for debugging
2. Build binaries when ANY release is created
3. Upload to the most recent release

## Testing
This PR will trigger version 0.3.5 → 0.3.6 and should finally build and upload binaries!

The debug output will help us understand exactly what release-please is outputting so we can fine-tune the conditions if needed.