### PR TITLE
feat(cli): add version subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "release-test-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,9 @@ enum Commands {
         #[arg(short, long)]
         json: bool,
     },
+
+    /// Display version information
+    Version,
 }
 
 fn main() -> Result<()> {
@@ -61,6 +64,11 @@ fn main() -> Result<()> {
             } else {
                 println!("{}", format_data(&model));
             }
+            Ok(())
+        }
+        Commands::Version => {
+            println!("release-test v{}", env!("CARGO_PKG_VERSION"));
+            println!("A demo CLI for automated release testing");
             Ok(())
         }
     };


### PR DESCRIPTION
## Summary
- Add Version subcommand to CLI for displaying version information
- Uses CARGO_PKG_VERSION environment variable to show current version
- Provides clear version output with description

## Test plan
- [x] Run cargo test - all tests pass
- [x] Run cargo clippy - no warnings
- [x] Run cargo fmt - code properly formatted
- [x] Test version subcommand manually

This change should trigger release v0.3.6 and test the binary building workflow with debug output.